### PR TITLE
chore(server.cfg): update to gamebuilds 3258

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -18,7 +18,7 @@ set steam_webApiKey "none"
 set resources_useSystemChat true
 
 ## https://docs.fivem.net/docs/server-manual/server-commands/#sv_enforcegamebuild-build
-set sv_enforceGameBuild 3095
+set sv_enforceGameBuild 3258
 
 ## https://docs.fivem.net/docs/server-manual/server-commands/#sv_filterrequestcontrol-mode
 set sv_filterRequestControl -1


### PR DESCRIPTION
Swapped gamebuild to 3258 as this is considered the latest "stable" release.

There's also various PRs where cfx members gave the impression that older builds perhaps shouldnt recieve support as long as it works on 3258 see here: https://github.com/citizenfx/fivem/pull/3343#issuecomment-2847052953